### PR TITLE
Add artisan command wrapping blade-formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
-# Laravel Package Template
+# Laravel Blade Formatter Package
 
-这是一个 Laravel 扩展包模板，包含基础目录结构、composer.json 配置、ServiceProvider 示例以及 PHPUnit + Orchestra Testbench 测试支持。
+该扩展包将 [blade-formatter](https://github.com/shufo/blade-formatter) Node.js 工具封装为 Laravel 包，并提供 `blade:format` Artisan 命令以格式化 Blade 模板。
 
 ## 安装
 
 ```bash
-composer require vendor/package-name
+composer require xmultibyte/blade-formatter
 ```
 
-## 开发
+## 使用
 
-- 修改 `composer.json` 中的 `vendor/package-name`、命名空间及作者信息
-- 在 `src/` 下编写扩展包代码
-- 在 `tests/` 下添加测试用例
+```bash
+php artisan blade:format resources/views/**/*.blade.php --write
+```
+
+更多命令参数请查看 `php artisan blade:format --help`。
 
 ## 测试
 
 ```bash
 composer install
-vendor/bin/phpunit
+composer test
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-  "name": "vendor/package-name",
-  "description": "A short description of what your Laravel package does.",
+  "name": "xmultibyte/blade-formatter",
+  "description": "Laravel package wrapper for the blade-formatter Node.js tool.",
   "keywords": [
     "laravel",
-    "package",
-    "your-keyword"
+    "blade",
+    "formatter"
   ],
-  "homepage": "https://github.com/vendor/package-name",
+  "homepage": "https://github.com/xmultibyte/blade-formatter",
   "license": "MIT",
   "authors": [
     {
@@ -16,7 +16,8 @@
   ],
   "require": {
     "php": "^8.1|^8.2|^8.3",
-    "illuminate/support": "^10.0|^11.0|^12.0"
+    "illuminate/support": "^10.0|^11.0|^12.0",
+    "symfony/process": "^6.0|^7.0"
   },
   "require-dev": {
     "orchestra/testbench": "^8.0|^9.0|^10.0",
@@ -24,21 +25,21 @@
   },
   "autoload": {
     "psr-4": {
-      "Vendor\\PackageName\\": "src/"
+      "XMultibyte\\LaravelPackage\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Vendor\\PackageName\\Tests\\": "tests/"
+      "XMultibyte\\LaravelPackage\\Tests\\": "tests/"
     }
   },
   "extra": {
     "laravel": {
       "providers": [
-        "Vendor\\PackageName\\PackageServiceProvider"
+        "XMultibyte\\LaravelPackage\\PackageServiceProvider"
       ],
       "aliases": {
-        "PackageName": "Vendor\\PackageName\\Facades\\PackageName"
+        "Package": "XMultibyte\\LaravelPackage\\Facades\\Package"
       }
     }
   },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Console/Commands/BladeFormatterCommand.php
+++ b/src/Console/Commands/BladeFormatterCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace XMultibyte\LaravelPackage\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+
+/**
+ * Class BladeFormatterCommand
+ *
+ * Artisan command to run the blade-formatter Node.js tool.
+ */
+class BladeFormatterCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'blade:format {paths?* : File paths or globs to format}'
+        . ' {--check-formatted : Only check that files are formatted}'
+        . ' {--write : Write formatting changes to files}'
+        . ' {--diff : Show diffs}'
+        . ' {--end-with-newline : End output with newline}'
+        . ' {--end-of-line= : End of line character (LF|CRLF)}'
+        . ' {--indent-size= : Indentation size}'
+        . ' {--wrap-line-length= : The length of line wrap size}'
+        . ' {--wrap-attributes= : The way to wrap attributes}'
+        . ' {--wrap-attributes-min-attrs= : Minimum number of attributes to wrap}'
+        . ' {--indent-inner-html : Indent <head> and <body> sections}'
+        . ' {--sort-tailwindcss-classes : Sort tailwindcss classes}'
+        . ' {--tailwindcss-config-path= : Path to tailwind config}'
+        . ' {--sort-html-attributes= : Sort HTML attributes}'
+        . ' {--custom-html-attributes-order= : Custom HTML attribute order}'
+        . ' {--no-single-quote : Use double quotes instead of single quotes}'
+        . ' {--extra-liners= : Comma separated list of tags with extra newline}'
+        . ' {--component-prefix= : Component prefix}'
+        . ' {--no-multiple-empty-lines : Merge multiple blank lines}'
+        . ' {--no-php-syntax-check : Disable PHP syntax checking}'
+        . ' {--no-trailing-comma-php : Disable trailing commas in PHP expression}'
+        . ' {--php-version= : PHP version for syntax checking}'
+        . ' {--progress : Print progress}'
+        . ' {--stdin : Format code provided on STDIN}'
+        . ' {--config= : Use the specified configuration file}'
+        . ' {--ignore-path= : Specify path of ignore file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Format Blade templates using blade-formatter';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $paths = $this->argument('paths');
+
+        $command = array_merge(['npx', '--yes', 'blade-formatter'], $paths);
+
+        foreach ($this->options() as $option => $value) {
+            if ($value === false || $value === null) {
+                continue;
+            }
+
+            $command[] = '--' . $option;
+
+            if (! is_bool($value)) {
+                $command[] = $value;
+            }
+        }
+
+        $process = new Process($command);
+        $process->run();
+
+        $this->output->write($process->getOutput());
+
+        if (! $process->isSuccessful()) {
+            $this->error($process->getErrorOutput());
+        }
+
+        return $process->getExitCode();
+    }
+}

--- a/src/PackageServiceProvider.php
+++ b/src/PackageServiceProvider.php
@@ -19,9 +19,10 @@ class PackageServiceProvider extends ServiceProvider
 
         $this->commands([
             Console\Commands\InstallCommand::class,
+            Console\Commands\BladeFormatterCommand::class,
         ]);
 
-        $this->publishes([__DIR__ . '/../config/package.php', config_path('package.php')], 'package-config');
+        $this->publishes([__DIR__ . '/../config/package.php' => config_path('package.php')], 'package-config');
         $this->publishes([__DIR__ . '/../database/migrations/' => database_path('migrations')], 'package-migrations');
         $this->publishes([__DIR__ . '/../resources/views/' => resource_path('views/vendor/package')], 'package-views');
         $this->publishes([__DIR__ . '/../resources/assets' => public_path('vendor/package')], 'package-assets');

--- a/tests/Feature/BladeFormatterCommandTest.php
+++ b/tests/Feature/BladeFormatterCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace XMultibyte\LaravelPackage\Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use XMultibyte\LaravelPackage\Tests\TestCase;
+
+/**
+ * @covers \XMultibyte\LaravelPackage\Console\Commands\BladeFormatterCommand
+ */
+class BladeFormatterCommandTest extends TestCase
+{
+    public function test_it_formats_blade_file(): void
+    {
+        $path = base_path('test.blade.php');
+
+        File::put($path, "@if(true)\n<p>hello</p>\n@endif");
+
+        $this->artisan('blade:format', [
+            'paths' => [$path],
+            '--write' => true,
+        ])->assertExitCode(0);
+
+        $this->assertSame("@if (true)\n    <p>hello</p>\n@endif\n", File::get($path));
+
+        File::delete($path);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace XMultibyte\LaravelPackage\Tests;
+
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use XMultibyte\LaravelPackage\PackageServiceProvider;
+
+/**
+ * Base test case for the package.
+ */
+abstract class TestCase extends OrchestraTestCase
+{
+    /**
+     * Get package providers for the application.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [PackageServiceProvider::class];
+    }
+}


### PR DESCRIPTION
## Summary
- add `blade:format` artisan command to run the Node.js blade-formatter tool
- expose command through service provider and document usage
- cover blade formatting via PHPUnit

## Testing
- `composer install`
- `composer test`
- `vendor/bin/testbench vendor:publish --tag=package-config`


------
https://chatgpt.com/codex/tasks/task_e_68996d4d8b44833084a6a9b63bcc9786